### PR TITLE
chore: pin go directive to 1.23.0

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,8 @@
 module github.com/smallstep/zcrypto
 
-go 1.23.6
+go 1.23.0
+
+toolchain go1.23.6
 
 require (
 	github.com/asaskevich/govalidator v0.0.0-20180720115003-f9ffefc3facf


### PR DESCRIPTION
PR #85 bumped the Go directive to 1.23.6 rather than 1.23.0, which requires corresponding Go directive bumps in all consumers. Instead use both a go and toolchain directive as follows:

- relax go directive to 1.23.0 to match the N-1 and N support statement and permit run/build with go1.23.0 and newer (Go treats this as mandatory)
- use the toolchain directive to recommend the latest 1.23.x (Go treats this as advisory)